### PR TITLE
Fix Firefox 3.6 Support

### DIFF
--- a/lib/cockpit/ui/cliView.js
+++ b/lib/cockpit/ui/cliView.js
@@ -116,7 +116,7 @@ CliView.prototype = {
 
         this.completer = this.doc.createElement('div');
         this.completer.className = 'cptCompletion VALID';
-        var style = window.getComputedStyle(input);
+        var style = window.getComputedStyle(input, null);
         this.completer.style.color = style.color;
         this.completer.style.fontSize = style.fontSize;
         this.completer.style.fontFamily = style.fontFamily;


### PR DESCRIPTION
Hi Joe,

I'm just playing around with Firefox 3.6 to get the keyboard done right and found that firefox 3.6 is not working. Firebug shows the message:

```
uncaught exception: [Exception... "Not enough arguments" nsresult: "0x80570001 (NS_ERROR_XPC_NOT_ENOUGH_ARGS)" location: "JS frame :: http://localhost:8080/support/cockpit/lib/cockpit/ui/cliView.js :: anonymous :: line 119" data: no]
```

The commit enclosed fixes this issue. The MDC page [1] says the null argument is optional, therefore I don't know exactly why this is necessary.

Cheers and enjoy your holidays!

Julian

[1] https://developer.mozilla.org/en/DOM:window.getComputedStyle
