### PR TITLE
Bug 694289 (testcmd): move command registration

### DIFF
--- a/lib/gclitest/index.js
+++ b/lib/gclitest/index.js
@@ -15,9 +15,11 @@ define(function(require, exports, module) {
   examiner.addSuite('gclitest/testSplit', require('gclitest/testSplit'));
   examiner.addSuite('gclitest/testCli', require('gclitest/testCli'));
   examiner.addSuite('gclitest/testHistory', require('gclitest/testHistory'));
-
   examiner.addSuite('gclitest/testRequire', require('gclitest/testRequire'));
 
   examiner.run();
+
+  // Register the 'test' command
+  require("test/commands").setup();
 
 });

--- a/lib/test/index.js
+++ b/lib/test/index.js
@@ -1,9 +1,0 @@
-/*
- * Copyright 2009-2011 Mozilla Foundation and contributors
- * Licensed under the New BSD license. See LICENSE.txt or:
- * http://opensource.org/licenses/BSD-3-Clause
- */
-
-define(function(require, exports, module) {
-  require("test/commands").setup();
-});


### PR DESCRIPTION
test/index wasn't being used, so we delete it and include the command
registration in the gclitest startup.

This code only affects the web version r? @MikeRatcliffe
Also it's beyond trivial.
