### PR TITLE
Bug 693265 (api): All moz builtin commands will need l10n

### DIFF
--- a/mozilla/gcli/index.js
+++ b/mozilla/gcli/index.js
@@ -4,11 +4,52 @@
  * http://opensource.org/licenses/BSD-3-Clause
  */
 
+var mozl10n = {};
+
+(function(aMozl10n) {
+  var temp = {};
+  Components.utils.import("resource://gre/modules/Services.jsm", temp);
+  var stringBundle = temp.Services.strings.createBundle(
+          "chrome://browser/locale/devtools/gclicommands.properties");
+
+  /**
+   * Lookup a string in the GCLI string bundle
+   * @param name The name to lookup
+   * @return The looked up name
+   */
+  aMozl10n.lookup = function(name) {
+    try {
+      return stringBundle.GetStringFromName(name);
+    }
+    catch (ex) {
+      throw new Error("Failure in lookup('" + name + "')");
+    }
+  };
+
+  /**
+   * Lookup a string in the GCLI string bundle
+   * @param name The name to lookup
+   * @param swaps An array of swaps. See stringBundle.formatStringFromName
+   * @return The looked up name
+   */
+  aMozl10n.lookupFormat = function(name, swaps) {
+    try {
+      return stringBundle.formatStringFromName(name, swaps, swaps.length);
+    }
+    catch (ex) {
+      throw new Error("Failure in lookupFormat('" + name + "')");
+    }
+  };
+
+})(mozl10n);
+
 define(function(require, exports, module) {
 
   // The API for use by command authors
   exports.addCommand = require('gcli/canon').addCommand;
   exports.removeCommand = require('gcli/canon').removeCommand;
+  exports.lookup = mozl10n.lookup;
+  exports.lookupFormat = mozl10n.lookupFormat;
 
   // Internal startup process. Not exported
   require('gcli/types/basic').startup();


### PR DESCRIPTION
so we should build in helper functions

The inspect command depends on these API changes, so I'd like to commit changes to this bug in 2 parts
r? @campd
