### PR TITLE
Remove unnecessary complexity from dom.createElement

### DIFF
--- a/lib/gcli/util.js
+++ b/lib/gcli/util.js
@@ -89,10 +89,7 @@ var dom = {};
 dom.NS_XHTML = 'http://www.w3.org/1999/xhtml';
 
 /**
- * Create an HTML or XHTML element depending on whether the document is HTML
- * or XML based. Where HTML/XHTML elements are distinguished by whether they
- * are created using doc.createElementNS('http://www.w3.org/1999/xhtml', tag)
- * or doc.createElement(tag)
+ * Create an HTML element.
  * If you want to create a XUL element then you don't have a problem knowing
  * what namespace you want.
  * @param doc The document in which to create the element
@@ -100,12 +97,7 @@ dom.NS_XHTML = 'http://www.w3.org/1999/xhtml';
  * @returns The created element
  */
 dom.createElement = function(doc, tag) {
-  if (dom.isXmlDocument(doc)) {
-    return doc.createElementNS(dom.NS_XHTML, tag);
-  }
-  else {
-    return doc.createElement(tag);
-  }
+  return doc.createElementNS(dom.NS_XHTML, tag);
 };
 
 /**


### PR DESCRIPTION
The HTML namespace is used in both HTML and XML documents.
