### PR TITLE
change to treat 'string' return types as plaintext

### DIFF
--- a/lib/gcli/cli.js
+++ b/lib/gcli/cli.js
@@ -1725,7 +1725,12 @@ Output.prototype.toDom = function(element) {
       node = util.createElement(document, 'p');
     }
 
-    util.setContents(node, output.toString());
+    if (this.command.returnType === 'string') {
+        util.setTextContent(node, output);
+    }
+    else {
+        util.setContents(node, output.toString());
+    }
   }
 
   // Make sure that links open in a new window.

--- a/lib/gcli/util.js
+++ b/lib/gcli/util.js
@@ -376,6 +376,13 @@ exports.setContents = function(elem, contents) {
 };
 
 /**
+ * Set the textContent of an element.
+ */
+exports.setTextContent = function(elem, contents) {
+  elem.textContent = contents;
+};
+
+/**
  * Load some HTML into the given document and return a DOM element.
  * This utility assumes that the html has a single root (other than whitespace)
  */


### PR DESCRIPTION
A command whose return type is 'string' can answer a string containing any HTML markup and GCLI will render it as an actual HTML element.  This is a security hole for Orion which allows clients to register arbitrary commands.  The attached patch ensures that 'string' return types are always treated as plaintext.
