### PR TITLE
union-1016578: Added union type and unit test

### DIFF
--- a/lib/gcli/connectors/direct.js
+++ b/lib/gcli/connectors/direct.js
@@ -43,6 +43,7 @@ var items = [
   require('../types/resource').items,
   require('../types/setting').items,
   require('../types/string').items,
+  require('../types/union').items,
 
   require('../cli').items,
 

--- a/lib/gcli/connectors/index.js
+++ b/lib/gcli/connectors/index.js
@@ -53,6 +53,7 @@ var items = [
   require('../types/resource').items,
   require('../types/setting').items,
   require('../types/string').items,
+  require('../types/union').items,
 
   require('../fields/delegate').items,
   require('../fields/selection').items,

--- a/lib/gcli/index.js
+++ b/lib/gcli/index.js
@@ -51,6 +51,7 @@ var items = [
   require('./types/resource').items,
   require('./types/setting').items,
   require('./types/string').items,
+  require('./types/union').items,
 
   require('./fields/delegate').items,
   require('./fields/selection').items,

--- a/lib/gcli/nls/strings.js
+++ b/lib/gcli/nls/strings.js
@@ -153,6 +153,10 @@ var i18n = {
     // in question has sub-commands, before a list of the matching sub-commands.
     subCommands: 'Sub-Commands',
 
+    // This error message is displayed when the command line is cannot find a
+    // match for the parse types.
+    commandParseError: 'Command line parsing error',
+
     // These strings are used to describe the 'context' command and its
     // 'prefix' parameter. See localization comment for 'connect' for an
     // explanation about 'prefix'.

--- a/lib/gcli/test/testResource.js
+++ b/lib/gcli/test/testResource.js
@@ -18,7 +18,7 @@
 
 var assert = require('../testharness/assert');
 
-var Promise = require('../util/promise').Promise;
+var promise = require('../util/promise');
 var util = require('../util/util');
 var resource = require('../types/resource');
 var Status = require('../types/types').Status;
@@ -138,7 +138,7 @@ function checkPrediction(res, prediction) {
     assert.is(typeof value.loadContents, 'function', 'resource for ' + name);
     assert.is(typeof value.element, 'object', 'resource for ' + name);
 
-    return Promise.resolve(res.stringify(value, context)).then(function(strung) {
+    return promise.resolve(res.stringify(value, context)).then(function(strung) {
       assert.is(strung, name, 'stringify for ' + name);
     });
   });

--- a/lib/gcli/test/testTypes.js
+++ b/lib/gcli/test/testTypes.js
@@ -18,7 +18,7 @@
 
 var assert = require('../testharness/assert');
 var util = require('../util/util');
-var Promise = require('../util/promise').Promise;
+var promise = require('../util/promise');
 var nodetype = require('../types/node');
 
 exports.setup = function(options) {
@@ -52,16 +52,20 @@ function forEachType(options, typeSpec, callback) {
     else if (name === 'remote') {
       return;
     }
+    else if (name === 'union') {
+      typeSpec.types = [{ name: "string" }];
+    }
 
     var type = types.createType(typeSpec);
     var reply = callback(type);
-    return Promise.resolve(reply).then(function(value) {
+    return promise.resolve(reply).then(function(value) {
       // Clean up
       delete typeSpec.name;
       delete typeSpec.requisition;
       delete typeSpec.data;
       delete typeSpec.delegateType;
       delete typeSpec.subtype;
+      delete typeSpec.types;
 
       return value;
     });
@@ -101,7 +105,7 @@ exports.testNullDefault = function(options) {
 
   return forEachType(options, { defaultValue: null }, function(type) {
     var reply = type.stringify(null, context);
-    return Promise.resolve(reply).then(function(str) {
+    return promise.resolve(reply).then(function(str) {
       assert.is(str, '', 'stringify(null) for ' + type.name);
     });
   });

--- a/lib/gcli/types/union.js
+++ b/lib/gcli/types/union.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014, Mozilla Foundation and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var Promise = require('../util/promise').Promise;
+var l10n = require('../util/l10n');
+var centralTypes = require("./types").centralTypes;
+var Conversion = require("./types").Conversion;
+var Status = require("./types").Status;
+
+exports.items = [
+  {
+    // The union type allows for a combination of different parameter types.
+    item: "type",
+    name: "union",
+
+    constructor: function() {
+      // Get the properties of the type. The last object in the list of types
+      // should always be a string type.
+      this.types = this.types.map(function(typeData) {
+        typeData.type = centralTypes.createType(typeData);
+        typeData.lookup = typeData.lookup;
+        return typeData;
+      });
+    },
+
+    stringify: function(value, context) {
+      if (value == null) {
+        return "";
+      }
+
+      var type = this.types.find(function(typeData) {
+        return typeData.name == value.type;
+      }).type;
+
+      return type.stringify(value[value.type], context);
+    },
+
+    parse: function(arg, context) {
+      // Try to parse the given argument in the provided order of the parameter
+      // types. Returns a promise containing the Conversion of the value that
+      // was parsed.
+      var self = this;
+
+      var onError = function(i) {
+        if (i >= self.types.length) {
+          return Promise.reject(new Conversion(undefined, arg, Status.ERROR,
+            l10n.lookup("commandParseError")));
+        } else {
+          return tryNext(i + 1);
+        }
+      };
+
+      var tryNext = function(i) {
+        var type = self.types[i].type;
+
+        try {
+          return type.parse(arg, context).then(function(conversion) {
+            if (conversion.getStatus() === Status.VALID ||
+                conversion.getStatus() === Status.INCOMPLETE) {
+              // Converts the conversion value of the union type to an
+              // object that identifies the current working type and the
+              // data associated with it
+              if (conversion.value) {
+                var oldConversionValue = conversion.value;
+                conversion.value = { type: type.name };
+                conversion.value[type.name] = oldConversionValue;
+              }
+              return conversion;
+            } else {
+              return onError(i);
+            }
+          });
+        } catch(e) {
+          return onError(i);
+        }
+      };
+
+      return Promise.resolve(tryNext(0));
+    },
+  }
+];


### PR DESCRIPTION
Added the union type and adjusted testTypes. The union type is implemented differently from firefox since it doesn't allow for arrow functions and the new promise library.

The require("promise") in testResource and testTypes needed to be adjusted since it would be undefined on firefox.
